### PR TITLE
arreglar botón devolver en prestados.php

### DIFF
--- a/devolver.php
+++ b/devolver.php
@@ -6,13 +6,15 @@ mysql_query('UPDATE prestamos SET pres_fecha_d = now() WHERE pres_codigo='.$pres
 
 // Aumentar la cantidad de ejemplares disponibles del libro devuelto
 $cons = mysql_query("
-	SELECT ejemplares_disp AS n, libr_codigo AS c FROM libros
+	SELECT libr_codigo AS c FROM libros
 	JOIN prestamos ON libros_libr_codigo = libr_codigo
 	WHERE pres_codigo = $pres_codigo", $link);
 
 $result = mysql_fetch_object($cons);
-$ejemplares_disp =  $result ->  n;
 $libr_codigo = $result ->  c;
-mysql_query("UPDATE libros SET ejemplares_disp=".($ejemplares_disp+1)." WHERE libr_codigo=$libr_codigo", $link);
+
+mysql_query("UPDATE libros SET ejemplares_disp = ejemplares_disp + 1 WHERE libr_codigo=$libr_codigo", $link);
+mysql_close($link);
+
 header("Location:prestados.php");
 ?>

--- a/prestados.php
+++ b/prestados.php
@@ -36,8 +36,8 @@
       and (pres_fecha_d is NULL or pres_fecha_d = '')",$link);
 
     while ($row = mysql_fetch_array($results)) {
-      $accion = '<a href="#" class="edit" data-toggle="modal" data-target="#modalDevolver" id='.$row['pres_codigo'].'>
-        <i class="fa fa-reply"> Devolver</i></a>';
+      $accion = '<a href="#" class="edit" data-toggle="modal" data-target="#modalDevolver" 
+                id='.$row['pres_codigo'].'><i class="fa fa-reply"> Devolver</i></a>';
 
         $add = array("0" => $row["pres_codigo"],
           "1" => $row["pres_fecha_s"],
@@ -66,20 +66,31 @@
     ?>
 
     <script>
-    var dataSet = <?php echo json_encode($encode);?>;
+      var dataSet = <?php echo json_encode($encode);?>;
       $(document).ready(function() {
         var table = $('#example').DataTable({
-            data: dataSet,
-            columns: [
-                { title: "Código" },
-                { title: "Fecha de salida" },
-                { title: "Plazo" },
-                { title: "Usuario" },
-                { title: "Libro" },
-                { title: "Operaciones" }
-            ]
-        } );
-      } );
+          data: dataSet,
+          columns: [
+            { title: "Código" },
+            { title: "Fecha de salida" },
+            { title: "Plazo" },
+            { title: "Usuario" },
+            { title: "Libro" },
+            { title: "Operaciones" }
+          ]
+        });
+
+        $('#example tbody').on('click', 'tr', function () {
+          var data = table.row( this ).data();
+          
+          // modificar id_prestamo del modal de confirmación
+          $('input[name="id_prestamo"]').val(data[0]); 
+
+          // escribir mensaje al confirmar devolución
+          $('#nombre_libro').text(`Confirmar devolución del libro "${data[4]}"`);
+        });
+
+      });
     </script>
     <?php mysql_close($link); ?>
   </head>
@@ -138,6 +149,31 @@
             <h2 style="margin-top:10px">Prestados</h2>
         </div>
 
+      <!-- Modal para confirmar devolución -->
+      <div class="modal fade" id="modalDevolver" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+              <h4 class="modal-title" id="myModalLabel">Confirmación<span id="load" style="display:none"> <img src="img/loading.gif"> Cargando...</span></h4>
+            </div>
+            <div class="modal-body">
+              <form id="formDevolver" method="GET" action="devolver.php">
+                <div class="form-group">
+                  <p id="nombre_libro"></p>
+                  <input type="hidden" name="id_prestamo" value="">
+                </div>
+                <div id="errorMessage">
+                </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-default" data-dismiss="modal">Cancelar</button>
+              <button type="submit" class="btn btn-primary">Aceptar</button>
+            </div>
+            </form>
+          </div>
+        </div>
+      </div>
       <table id="example" class="display" width="100%"></table>
     </div>
 


### PR DESCRIPTION
El botón devolver en prestados.php dejó de funcionar debido a la modificación de la variable $accion, que seguía  activando el modal para confirmar la devolución, en lugar de enviar el id del préstamo a devolver.php.